### PR TITLE
Slotted input and header

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -19,7 +19,7 @@
   },
   "license": "Apache-2.0",
   "dependencies": {
-    "iron-dropdown": "polymerelements/iron-dropdown#^1.3.0",
+    "iron-dropdown": "polymerelements/iron-dropdown#^2.2.1",
     "iron-overlay-behavior": "polymerelements/iron-overlay-behavior#^1.3.2",
     "iron-icon": "polymerelements/iron-icon#^1.0.7",
     "iron-input": "polymerelements/iron-input#^1.0.8",

--- a/test/basic.html
+++ b/test/basic.html
@@ -180,16 +180,16 @@
 
       it('should format display correctly', function() {
         datepicker.value = '2000-02-01';
-        expect(datepicker.$.input.bindValue).to.equal('2/1/2000');
+        expect(datepicker.$.input.bindValue).to.equal('01 Feb 2000');
         datepicker.value = '1999-12-31';
-        expect(datepicker.$.input.bindValue).to.equal('12/31/1999');
+        expect(datepicker.$.input.bindValue).to.equal('31 Dec 1999');
       });
 
       it('should format display correctly with sub 100 years', function() {
         datepicker.value = '+000001-02-01';
-        expect(datepicker.$.input.bindValue).to.equal('2/1/0001');
+        expect(datepicker.$.input.bindValue).to.equal('01 Feb 0001');
         datepicker.value = '+000099-02-01';
-        expect(datepicker.$.input.bindValue).to.equal('2/1/0099');
+        expect(datepicker.$.input.bindValue).to.equal('01 Feb 0099');
       });
 
       it('should not show clear icon', function() {

--- a/test/keyboard-input.html
+++ b/test/keyboard-input.html
@@ -98,14 +98,14 @@
         });
 
         it('should focus parsed date', function() {
-          inputText('1/20/2000');
+          inputText('20/1/2000');
 
           expect(focusedDate().getMonth()).to.equal(0);
           expect(focusedDate().getDate()).to.equal(20);
         });
 
         it('should update focus on input change', function() {
-          inputText('1/20/20');
+          inputText('20/1/20');
           inputText('17');
 
           expect(focusedDate().getMonth()).to.equal(0);
@@ -193,7 +193,7 @@
 
           datepicker.addEventListener('iron-overlay-opened', function() {
             arrowDown();
-            expect(datepicker._inputValue).to.equal('1/8/2000');
+            expect(datepicker._inputValue).to.equal('08 Jan 2000');
             done();
           });
           arrowDown();
@@ -215,7 +215,7 @@
             arrowDown();
             target = overlay;
             arrowDown();
-            expect(datepicker._inputValue).to.equal('1/15/2000');
+            expect(datepicker._inputValue).to.equal('15 Jan 2000');
             done();
           });
           arrowDown();
@@ -332,7 +332,7 @@
               arrowDown();
               arrowDown();
               esc();
-              expect(target.value).to.equal('1/1/2000');
+              expect(target.value).to.equal('01 Jan 2000');
               done();
             });
           });
@@ -396,7 +396,7 @@
           });
 
           it('should parse two digits', function() {
-            inputText('6/20');
+            inputText('20/6');
             var result = focusedDate();
             expect(result.getFullYear()).to.equal(today.getFullYear());
             expect(result.getMonth()).to.equal(5);
@@ -404,7 +404,7 @@
           });
 
           it('should parse three digits', function() {
-            inputText('6/20/1999');
+            inputText('20/6/1999');
             var result = focusedDate();
             expect(result.getFullYear()).to.equal(1999);
             expect(result.getMonth()).to.equal(5);

--- a/vaadin-date-picker-behavior.html
+++ b/vaadin-date-picker-behavior.html
@@ -330,7 +330,7 @@
       }
     },
 
-    _close: function(e) {
+    _close: function(e) { 
       if (e) {
         e.stopPropagation();
       }
@@ -545,6 +545,9 @@
         } else {
           this._selectedDate = null;
           this._inputValue = inputValue;
+          if (inputValue !== '') {
+            this.fire('invalid-date');
+          } 
         }
       } else if (this._focusedDate) {
         this._selectedDate = this._focusedDate;
@@ -644,7 +647,7 @@
 
           break;
         case 'enter':
-          if (this.$.overlay.focusedDate) {
+          if (this.$.overlay.focusedDate && document.activeElement === this) {
             this._selectedDate = this.$.overlay.focusedDate;
           }
           this.close();

--- a/vaadin-date-picker-behavior.html
+++ b/vaadin-date-picker-behavior.html
@@ -188,33 +188,70 @@
             today: 'Today',
             cancel: 'Cancel',
             formatDate: function(d) {
-              var year = d.getFullYear();
-              var yearString = year.toString();
-              if (yearString.length < 3 && year >= 0) {
-                yearString = (year < 10 ? '000' : '00') + year;
-              }
-              return (d.getMonth() + 1) + '/' + d.getDate() + '/' + yearString;
+              var dateArr = d.toString().split(' ');
+              var dateStr = dateArr[2] + ' ' + dateArr [1] + ' ' + dateArr[3];
+              return dateStr;
             },
             parseDate: function(text) {
-              var parts = text.split('/');
+              console.log('text', text);
+              var dateRegEx = /(^\d{1,2}$)/;
+              var monthRegEx = /([a-zA-Z]+|^\d{1,2}$)/;
+              if(text === '') {
+                window.dispatchEvent(new CustomEvent('date-input-cleared'));
+                return false;
+              }
+              var parts;
+              if (text.indexOf('/') !== -1) {
+                parts = text.split('/');
+              } else if (text.indexOf('-') !== -1) {
+                parts = text.split('-');
+              } else {
+                parts = text.split(' ');
+              }
+              if (!dateRegEx.test(parts[0])) {
+                window.dispatchEvent(new CustomEvent('invalid-date', {value: text}));
+                return false;
+              }
+              if (!!parts[1]) {
+                if (!monthRegEx.test(parts[1])) {
+                  window.dispatchEvent(new CustomEvent('invalid-date', {value: text}));
+                  return false;
+                }
+              }
               var today = new Date();
               var date, month = today.getMonth(), year = today.getFullYear();
+              var getMonthIndex = (monthInput) => {
+                var inputMonthName = this.monthNames.find(function(monthName){
+                  return monthName.toLowerCase().indexOf(monthInput.toLowerCase()) === 0;
+                });
+                return this.monthNames.indexOf(inputMonthName);
+              }
 
+              var getMonth = (month) => {
+                if (isNaN(parseInt(month))) {
+                  return getMonthIndex(month);
+                } else {
+                  if (month > 12) {
+                    month = month % 12;
+                  }
+                  return parseInt(month) - 1;
+                }
+              }
+        
               if (parts.length === 3) {
                 year = parseInt(parts[2]);
                 if (parts[2].length < 3 && year >= 0) {
                   year += year < 50 ? 2000 : 1900;
                 }
-                month = parseInt(parts[0]) - 1;
-                date = parseInt(parts[1]);
+                month = getMonth(parts[1]);
+                date = parseInt(parts[0]);
               } else if (parts.length === 2) {
-                month = parseInt(parts[0]) - 1;
-                date = parseInt(parts[1]);
+                month = getMonth(parts[1]);
+                date = parseInt(parts[0]);
               } else if (parts.length === 1) {
                 date = parseInt(parts[0]);
               }
-
-              if (date !== undefined) {
+              if (typeof date !== 'undefined') {
                 var result = new Date(0, 0); // Wrong date (1900-01-01), but with midnight in local time
                 result.setFullYear(year);
                 result.setMonth(month);

--- a/vaadin-date-picker-behavior.html
+++ b/vaadin-date-picker-behavior.html
@@ -546,7 +546,7 @@
           this._selectedDate = null;
           this._inputValue = inputValue;
           if (inputValue !== '') {
-            this.fire('invalid-date');
+            this.fire('invalid-date', {value: inputValue});
           } 
         }
       } else if (this._focusedDate) {

--- a/vaadin-date-picker-behavior.html
+++ b/vaadin-date-picker-behavior.html
@@ -208,12 +208,12 @@
                 parts = text.split(' ');
               }
               if (!dateRegEx.test(parts[0])) {
-                window.dispatchEvent(new CustomEvent('invalid-date', {value: text}));
+                window.dispatchEvent(new CustomEvent('invalid-date', {"detail":{value: text}}));
                 return false;
               }
               if (!!parts[1]) {
                 if (!monthRegEx.test(parts[1])) {
-                  window.dispatchEvent(new CustomEvent('invalid-date', {value: text}));
+                  window.dispatchEvent(new CustomEvent('invalid-date', {"detail":{value: text}}));
                   return false;
                 }
               }

--- a/vaadin-date-picker-behavior.html
+++ b/vaadin-date-picker-behavior.html
@@ -193,7 +193,6 @@
               return dateStr;
             },
             parseDate: function(text) {
-              console.log('text', text);
               var dateRegEx = /(^\d{1,2}$)/;
               var monthRegEx = /([a-zA-Z]+|^\d{1,2}$)/;
               if(text === '') {

--- a/vaadin-date-picker-behavior.html
+++ b/vaadin-date-picker-behavior.html
@@ -659,14 +659,29 @@
         case 'tab':
           if (this.opened) {
             e.preventDefault();
+            var button = this.queryEffectiveChildren('ps-ring-button-solid')
+
+            var focusTarget = this.$.overlay;
+            if (this._hasDistributedChildren) {
+              if (document.activeElement == this.inputElement.$$('input')) {
+                focusTarget = button;
+              }
+            }
             // Clear the selection range (remains visible on IE)
             if (this.inputElement.setSelectionRange) {
               this.inputElement.setSelectionRange(0, 0);
             }
             if (e.shiftKey) {
-              this.$.overlay.focusCancel();
-            } else {
-              this.$.overlay.focus();
+              if (document.activeElement === this.$.overlay) {
+                focusTarget = button.$$('button');
+              } else if (document.activeElement === button.$$('button')) {
+                focusTarget = this.inputElement.$.input;
+              }
+              this.fire('focus', {}, {node: focusTarget});
+            } 
+            
+            focusTarget.focus();  
+            if (focusTarget === this.$.overlay) {
               this.$.overlay.revealDate(this._focusedDate);
             }
 

--- a/vaadin-date-picker-behavior.html
+++ b/vaadin-date-picker-behavior.html
@@ -220,9 +220,9 @@
               var today = new Date();
               var date, month = today.getMonth(), year = today.getFullYear();
               var getMonthIndex = (monthInput) => {
-                var inputMonthName = this.monthNames.find(function(monthName){
+                var inputMonthName = this.monthNames.filter(function(monthName){
                   return monthName.toLowerCase().indexOf(monthInput.toLowerCase()) === 0;
-                });
+                })[0];
                 return this.monthNames.indexOf(inputMonthName);
               }
 

--- a/vaadin-date-picker-light.html
+++ b/vaadin-date-picker-light.html
@@ -56,6 +56,7 @@ need to define the name of value property using the `attrForValue` property.
       }
 
       #header {
+        display: none;
         box-sizing: border-box;
         height: 64px;
         width: 420px;
@@ -63,6 +64,11 @@ need to define the name of value property using the `attrForValue` property.
         background-color: white;
         box-shadow: 0 2px 2px 0 rgba(0,0,0,.14), 0 1px 5px 0 rgba(0,0,0,.12), 0 3px 1px -2px rgba(0,0,0,.2);
         z-index: 10;
+        position: relative;
+      }
+
+      #header.with-button {
+        display: block;
       }
 
     </style>
@@ -77,13 +83,11 @@ need to define the name of value property using the `attrForValue` property.
         on-iron-overlay-canceled="_preventCancelOnComponentAccess"
         opened="{{opened}}"
         no-auto-focus>
-        <template is="dom-if" if="[[_hasDistributedButtons]]">
-          <div
-            id="header"
-            class="dropdown-content">
-            <slot name="buttons"></slot>
-          </div>
-        </template>
+        <div
+          id="header"
+          class="dropdown-content">
+          <slot name="buttons" id="buttons"></slot>
+        </div>
         <vaadin-date-picker-overlay
         id="overlay" i18n="[[i18n]]"
         fullscreen$=[[_fullscreen]]
@@ -123,19 +127,28 @@ need to define the name of value property using the `attrForValue` property.
           type: String,
           value: 'bind-value'
         },
-        _hasDistributedButtons: {
-          type: Boolean,
-          value: function () {
-            var children = this.queryEffectiveChildren('ps-ring-button');
-            console.log(children);
-            return true;
-          }
-        }
       },
 
       listeners:
       {
         'input': '_userInputValueChanged'
+      },
+
+      ready: function() {
+        var _boundNodeObserverHandler = this._headerVisibilityToggle.bind(this);
+        // Observe nodes added/removed from the slot in header
+        this._buttonObserver = Polymer.dom(this.$.header).observeNodes(_boundNodeObserverHandler);
+      },
+
+      /**
+       * Toggle class on the header if a button is or isn't slotted into the header
+       **/
+      _headerVisibilityToggle: function(nodes) {
+        if (nodes.addedNodes.length > 0) {
+          this.$.header.classList.add('with-button');
+        } else {
+          this.$.header.classList.remove('with-button');
+        }
       },
 
       _input: function()

--- a/vaadin-date-picker-light.html
+++ b/vaadin-date-picker-light.html
@@ -56,7 +56,7 @@ need to define the name of value property using the `attrForValue` property.
       }
 
       #header {
-        display: none;
+        display: block;
         box-sizing: border-box;
         height: 64px;
         width: 420px;
@@ -67,8 +67,8 @@ need to define the name of value property using the `attrForValue` property.
         position: relative;
       }
 
-      #header.with-button {
-        display: block;
+      #header[hidden] {
+        display: none;
       }
 
     </style>
@@ -85,7 +85,8 @@ need to define the name of value property using the `attrForValue` property.
         no-auto-focus>
         <div
           id="header"
-          class="dropdown-content">
+          class="dropdown-content"
+          hidden$=[[!_hasDistributedChildren]]>
           <slot name="buttons" id="buttons"></slot>
         </div>
         <vaadin-date-picker-overlay
@@ -127,6 +128,14 @@ need to define the name of value property using the `attrForValue` property.
           type: String,
           value: 'bind-value'
         },
+        /**
+         * Flag detailing the existence of a button in the buttons slot of the header.
+         * Manages visibility of the datepicker header.
+         */
+        _hasDistributedChildren: {
+          type: Boolean,
+          value: false
+        }
       },
 
       listeners:
@@ -145,9 +154,9 @@ need to define the name of value property using the `attrForValue` property.
        **/
       _headerVisibilityToggle: function(nodes) {
         if (nodes.addedNodes.length > 0) {
-          this.$.header.classList.add('with-button');
+          this.set('_hasDistributedChildren', true);
         } else {
-          this.$.header.classList.remove('with-button');
+          this.set('_hasDistributedChildren', false);
         }
       },
 

--- a/vaadin-date-picker-light.html
+++ b/vaadin-date-picker-light.html
@@ -51,14 +51,14 @@ need to define the name of value property using the `attrForValue` property.
 
       #overlay {
         height: 100vh;
-        width: 365px;
+        width: 420px;
         z-index: 1;
       }
 
       #header {
         box-sizing: border-box;
         height: 64px;
-        width: 365px;
+        width: 420px;
         padding: 10px 15px;
         background-color: white;
         box-shadow: 0 2px 2px 0 rgba(0,0,0,.14), 0 1px 5px 0 rgba(0,0,0,.12), 0 3px 1px -2px rgba(0,0,0,.2);

--- a/vaadin-date-picker-light.html
+++ b/vaadin-date-picker-light.html
@@ -52,10 +52,21 @@ need to define the name of value property using the `attrForValue` property.
       #overlay {
         height: 100vh;
         width: 365px;
+        z-index: 1;
+      }
+
+      #header {
+        box-sizing: border-box;
+        height: 64px;
+        width: 365px;
+        padding: 10px 15px;
+        background-color: white;
+        box-shadow: 0 2px 2px 0 rgba(0,0,0,.14), 0 1px 5px 0 rgba(0,0,0,.12), 0 3px 1px -2px rgba(0,0,0,.2);
+        z-index: 10;
       }
 
     </style>
-    <content></content>
+    <slot name="input"></slot>
 
     <iron-dropdown
         id="dropdown"
@@ -66,7 +77,14 @@ need to define the name of value property using the `attrForValue` property.
         on-iron-overlay-canceled="_preventCancelOnComponentAccess"
         opened="{{opened}}"
         no-auto-focus>
-      <vaadin-date-picker-overlay
+        <template is="dom-if" if="[[_hasDistributedButtons]]">
+          <div
+            id="header"
+            class="dropdown-content">
+            <slot name="buttons"></slot>
+          </div>
+        </template>
+        <vaadin-date-picker-overlay
         id="overlay" i18n="[[i18n]]"
         fullscreen$=[[_fullscreen]]
         label=[[label]]
@@ -77,6 +95,7 @@ need to define the name of value property using the `attrForValue` property.
         max-date="[[_maxDate]]"
         role="dialog">
       </vaadin-date-picker-overlay>
+
     </iron-dropdown>
 
     <iron-media-query
@@ -103,6 +122,14 @@ need to define the name of value property using the `attrForValue` property.
         {
           type: String,
           value: 'bind-value'
+        },
+        _hasDistributedButtons: {
+          type: Boolean,
+          value: function () {
+            var children = this.queryEffectiveChildren('ps-ring-button');
+            console.log(children);
+            return true;
+          }
         }
       },
 

--- a/vaadin-date-picker-light.html
+++ b/vaadin-date-picker-light.html
@@ -85,7 +85,7 @@ need to define the name of value property using the `attrForValue` property.
         no-auto-focus>
         <div
           id="header"
-          class="dropdown-content"
+          slot="dropdown-content"
           hidden$=[[!_hasDistributedChildren]]>
           <slot name="buttons" id="buttons"></slot>
         </div>
@@ -94,7 +94,7 @@ need to define the name of value property using the `attrForValue` property.
         fullscreen$=[[_fullscreen]]
         label=[[label]]
         selected-date="{{_selectedDate}}"
-        class="dropdown-content"
+        slot="dropdown-content"
         focused-date="{{_focusedDate}}"
         min-date="[[_minDate]]"
         max-date="[[_maxDate]]"

--- a/vaadin-date-picker-overlay.html
+++ b/vaadin-date-picker-overlay.html
@@ -248,6 +248,10 @@
         clip: rect(0, 0, 0, 0);
         clip-path: inset(100%);
       }
+      
+      #month {
+        margin: 0 auto;
+      }
     </style>
 
     <div id="announcer" role="alert" aria-live="polite">
@@ -273,6 +277,7 @@
       <vaadin-infinite-scroller id="scroller" on-custom-scroll="_onMonthScroll" on-touchstart="_onMonthScrollTouchStart" item-height="300" buffer-size="6" active="[[initialPosition]]">
         <template>
           <vaadin-month-calendar
+            id="month"
             i18n="[[i18n]]"
             month="[[_dateAfterXMonths(index)]]"
             selected-date="{{selectedDate}}"

--- a/vaadin-date-picker.html
+++ b/vaadin-date-picker.html
@@ -226,7 +226,7 @@ If you want to replace the default input field with a custom implementation, you
           fullscreen$="[[_fullscreen]]"
           label="[[label]]"
           selected-date="{{_selectedDate}}"
-          class="dropdown-content"
+          slot="dropdown-content"
           focused-date="{{_focusedDate}}"
           show-week-numbers="[[showWeekNumbers]]"
           min-date="[[_minDate]]"

--- a/vaadin-month-calendar.html
+++ b/vaadin-month-calendar.html
@@ -115,8 +115,7 @@
         @apply(--vaadin-date-picker-calendar-weeknumber-cell);
       }
 
-	  #monthGrid div:hover,
-	  #monthGrid div.weeknumber:hover {
+	  #monthGrid div[role="button"]:hover {
 		  @apply(--vaadin-date-picker-calendar-cell-hover);
 	  }
     </style>


### PR DESCRIPTION
Updates from `<content>` to `<slot>` elements for distributed nodes.

Adds a conditionally stamped header to the datepicker, using `observeNodes` to determine if a button has been slotted in from the implementation of the datepicker.

Adds some logic to the key handler `_onKeyDown` to handle presses of the **tab** key in the datepicker if there is a distributed button.

Updates test values to check that date parsing and formatting functions are returning the values we want.

### TODO:
- [ ] Try to abstract out the reference to `ps-ring-button-solid`. Perhaps query against an element _type_?